### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Josh Baker [@tidwall](http://twitter.com/tidwall)
 
 ## License
 
-Redcon source code is available under the MIT [License](/LICENSE).
+Match source code is available under the MIT [License](/LICENSE).


### PR DESCRIPTION
Fix name of package from `redcon` to `match` in readme.md